### PR TITLE
Remove hard dep on matplotlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(name="logpyle",
 
       install_requires=[
           "pytools>=2011.1",
-          "matplotlib",
           "pymbolic",
       ],
 


### PR DESCRIPTION
Matplotlib is a very heavy-weight dependency (which is obnoxious and unnecessary when running on a big machine), and it's only required for some use cases.