### PR TITLE
Remove explicit __init__ in log.rst

### DIFF
--- a/doc/log.rst
+++ b/doc/log.rst
@@ -101,6 +101,6 @@ your time series data, for example:
   step 2000 and 3000
 - Make a scatterplot correlating memory transfer amounts and simulation time
 
-.. automodule:: logpyle.__init__
+.. automodule:: logpyle
 
 .. no-doctest


### PR DESCRIPTION
Closes #17

This reverts b2279c6c527b90e6de145b0fbca571fbaa470819, which was causing #17. I'd argue b2279c6c527b90e6de145b0fbca571fbaa470819 is unnecessary (the docs build fine for me without it).