### PR TITLE
undo numpy workaround for Python 3.9/MacOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,6 @@ jobs:
         - name: Install prerequisites
           run: |
             pip install wheel
-            if [ "$RUNNER_OS" == "macOS" ]; then
-              # workaround for https://github.com/numpy/numpy/issues/15947
-              brew install openblas
-              OPENBLAS="$(brew --prefix openblas)" pip install numpy
-            fi
             pip install matplotlib
             pip install -e .      
         - name: Run and test example


### PR DESCRIPTION
Underlying issue has been fixed apparently: https://github.com/pandas-dev/pandas/issues/37057#issuecomment-720152789