### PR TITLE
adjust file naming

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
         - name: Run and test example
           run: |
             python examples/log.py
-            runalyzer-gather summary.dat log.dat
-            runalyzer -m summary.dat -c 'dbplot(q("select $t_sim, $t_step"))'
+            runalyzer-gather summary.sqlite log.sqlite
+            runalyzer -m summary.sqlite -c 'dbplot(q("select $t_sim, $t_step"))'
 
             mpirun -n 4 examples/log-mpi.py

--- a/examples/log-mpi.py
+++ b/examples/log-mpi.py
@@ -20,7 +20,7 @@ class Fifteen(LogQuantity):
 
 
 def main():
-    logmgr = LogManager("mpi-log.dat", "wu", MPI.COMM_WORLD)
+    logmgr = LogManager("mpi-log.sqlite", "wu", MPI.COMM_WORLD)
 
     # Set a run property
     logmgr.set_constant("myconst", uniform(0, 1))

--- a/examples/log.py
+++ b/examples/log.py
@@ -15,7 +15,7 @@ class Fifteen(LogQuantity):
 
 
 def main():
-    logmgr = LogManager("log.dat", "w")
+    logmgr = LogManager("log.sqlite", "w")
 
     # set a run property
     logmgr.set_constant("myconst", uniform(0, 1))

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -442,12 +442,12 @@ class LogManager:
             if self.is_parallel:
                 file_base += "-rank%d" % self.rank
 
-
         while True:
             suffix = ""
 
             if mode == "wu":
-                suffix = self.mpi_comm.bcast(_get_unique_suffix(), root=self.head_rank)
+                suffix = self.mpi_comm.bcast(_get_unique_suffix(),
+                                             root=self.head_rank)
 
             filename = file_base + suffix + file_extension
 

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -435,7 +435,8 @@ class LogManager:
         import sqlite3 as sqlite
 
         if filename is None:
-            filename = ":memory:"
+            file_base = ":memory:"
+            file_extension = ""
         else:
             import os
             file_base, file_extension = os.path.splitext(filename)
@@ -445,7 +446,7 @@ class LogManager:
         while True:
             suffix = ""
 
-            if mode == "wu":
+            if mode == "wu" and not file_base == ":memory:":
                 suffix = self.mpi_comm.bcast(_get_unique_suffix(),
                                              root=self.head_rank)
 

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -447,8 +447,11 @@ class LogManager:
             suffix = ""
 
             if mode == "wu" and not file_base == ":memory:":
-                suffix = self.mpi_comm.bcast(_get_unique_suffix(),
-                                             root=self.head_rank)
+                if self.is_parallel:
+                    suffix = self.mpi_comm.bcast(_get_unique_suffix(),
+                                                 root=self.head_rank)
+                else:
+                    suffix = _get_unique_suffix()
 
             filename = file_base + suffix + file_extension
 

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -289,7 +289,7 @@ def _get_unique_id():
 
 def _get_unique_suffix():
     from datetime import datetime
-    return "-" + datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    return "-" + datetime.utcnow().strftime("%Y%m%d-%H%M%S")
 
 
 def _set_up_schema(db_conn):


### PR DESCRIPTION
1. set file extension for examples to ".sqlite"
    - works better with file name completion and clarifies what the file is
2. when using mode 'wu', create unique file name based on time stamp and broadcast name from head rank
  a) makes file ordering more natural
  b) makes it clear which files belong together
3. make sure that the file extension is the last element of the file name

before:
```
mpi-log.dat-rank0-dLXwsl  
mpi-log.dat-rank1-4NT7fT  
mpi-log.dat-rank2-MsOH6m
mpi-log.dat-rank3-rWkWtP
```

after:
```
mpi-log-rank0-20201202203827.sqlite
mpi-log-rank1-20201202203827.sqlite
mpi-log-rank2-20201202203827.sqlite
mpi-log-rank3-20201202203827.sqlite
```