### PR TITLE
watches: flush after printing

### DIFF
--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -1041,7 +1041,8 @@ class LogManager:
 
             if self.watches:
                 print(" | ".join(
-                        compute_watch_str(watch) for watch in self.watches), flush=True)
+                        compute_watch_str(watch) for watch in self.watches),
+                      flush=True)
 
         ticks_per_sec = self.tick_count/max(1, time()-self.start_time)
         self.next_watch_tick = self.tick_count + int(max(1, ticks_per_sec))

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -1041,7 +1041,7 @@ class LogManager:
 
             if self.watches:
                 print(" | ".join(
-                        compute_watch_str(watch) for watch in self.watches))
+                        compute_watch_str(watch) for watch in self.watches), flush=True)
 
         ticks_per_sec = self.tick_count/max(1, time()-self.start_time)
         self.next_watch_tick = self.tick_count + int(max(1, ticks_per_sec))


### PR DESCRIPTION
Some batch systems (*cough* jsrun *cough*) dink around with stdout
and buffer all output until execution is finished.