### PR TITLE
Add value setter for simple logged quantities.

### DIFF
--- a/examples/log-mpi.py
+++ b/examples/log-mpi.py
@@ -64,7 +64,7 @@ def main():
     vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
     logmgr.add_quantity(vis_timer)
     logmgr.add_quantity(Fifteen("fifteen"))
-    logmgr.add_quantity(UserLogQuantity("q1"))
+    logmgr.add_quantity(PushLogQuantity("q1"))
 
     # Watches are printed periodically during execution
     logmgr.add_watches([("step.max", "step={value} "),

--- a/examples/log-mpi.py
+++ b/examples/log-mpi.py
@@ -15,16 +15,13 @@ class UserLogQuantity(LogQuantity):
     """Logging support for arbitrary user quantities."""
 
     def __init__(self, name, value=None, unit=None,
-          description=None, user_function=None) -> None:
+          description=None) -> None:
         LogQuantity.__init__(self, name=name, unit=unit,
                              description=description)
         self._quantity_value = value
-        self._uf = user_function
 
     def __call__(self) -> float:
         """Return the actual logged quantity."""
-        if self._uf:
-            return self._uf(self._quantity_value)
         return self._quantity_value
 
     def set_quantity_value(self, value: Any) -> None:
@@ -52,9 +49,6 @@ def main():
 
     print(f"Rank {rank} of {size} ranks.")
 
-    def f1(q):
-        return (rank + 1)*q
-
     # Generic run metadata, such as command line, host, and time
     add_run_info(logmgr)
 
@@ -69,22 +63,17 @@ def main():
     logmgr.add_quantity(vis_timer)
     logmgr.add_quantity(Fifteen("fifteen"))
     logmgr.add_quantity(UserLogQuantity("q1"))
-    logmgr.add_quantity(UserLogQuantity("q2", value=0,
-                                        user_function=f1))
 
     # Watches are printed periodically during execution
     logmgr.add_watches([("step.max", "step={value} "),
                         ("t_step.min", "\nt_step({value:g},"),
                         ("t_step.max", " {value:g})\n"),
                         ("q1.max", " UserQ1:({value:g}), "),
-                        ("q2.min", "UserQ2:({value:g},"),
-                        ("q2.max", "{value:g})\n"),
                         "t_sim.max", "fifteen", "t_vis.max"])
 
     for istep in range(200):
         logmgr.tick_before()
         logmgr.set_quantity_value("q1", 2*istep)
-        logmgr.set_quantity_value("q2", istep)
 
         dt = uniform(0.01, 0.1)
         set_dt(logmgr, dt)

--- a/examples/log-mpi.py
+++ b/examples/log-mpi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from time import sleep
+from typing import Any
 from random import uniform
 from logpyle import (LogManager, add_general_quantities,
         add_simulation_quantities, add_run_info, IntervalTimer,
@@ -8,6 +9,27 @@ from logpyle import (LogManager, add_general_quantities,
 
 from warnings import warn
 from mpi4py import MPI
+
+
+class UserLogQuantity(LogQuantity):
+    """Logging support for arbitrary user quantities."""
+
+    def __init__(self, name, value=None, unit=None,
+          description=None, user_function=None) -> None:
+        LogQuantity.__init__(self, name=name, unit=unit,
+                             description=description)
+        self._quantity_value = value
+        self._uf = user_function
+
+    def __call__(self) -> float:
+        """Return the actual logged quantity."""
+        if self._uf:
+            return self._uf(self._quantity_value)
+        return self._quantity_value
+
+    def set_quantity_value(self, value: Any) -> None:
+        """Set the value of the logged quantity."""
+        self._quantity_value = value
 
 
 class Fifteen(LogQuantity):
@@ -30,6 +52,9 @@ def main():
 
     print(f"Rank {rank} of {size} ranks.")
 
+    def f1(q):
+        return (rank + 1)*q
+
     # Generic run metadata, such as command line, host, and time
     add_run_info(logmgr)
 
@@ -43,14 +68,23 @@ def main():
     vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
     logmgr.add_quantity(vis_timer)
     logmgr.add_quantity(Fifteen("fifteen"))
+    logmgr.add_quantity(UserLogQuantity("q1"))
+    logmgr.add_quantity(UserLogQuantity("q2", value=0,
+                                        user_function=f1))
 
     # Watches are printed periodically during execution
     logmgr.add_watches([("step.max", "step={value} "),
-        ("t_step.min", "\nt_step({value:g},"), ("t_step.max", " {value:g})\n"),
-        "t_sim.max", "fifteen", "t_vis.max"])
+                        ("t_step.min", "\nt_step({value:g},"),
+                        ("t_step.max", " {value:g})\n"),
+                        ("q1.max", " UserQ1:({value:g}), "),
+                        ("q2.min", "UserQ2:({value:g},"),
+                        ("q2.max", "{value:g})\n"),
+                        "t_sim.max", "fifteen", "t_vis.max"])
 
     for istep in range(200):
         logmgr.tick_before()
+        logmgr.set_quantity_value("q1", 2*istep)
+        logmgr.set_quantity_value("q2", istep)
 
         dt = uniform(0.01, 0.1)
         set_dt(logmgr, dt)

--- a/examples/log-mpi.py
+++ b/examples/log-mpi.py
@@ -11,7 +11,7 @@ from warnings import warn
 from mpi4py import MPI
 
 
-class UserLogQuantity(LogQuantity):
+class PushLogQuantity(LogQuantity):
     """Logging support for arbitrary user quantities."""
 
     def __init__(self, name, value=None, unit=None,
@@ -22,7 +22,9 @@ class UserLogQuantity(LogQuantity):
 
     def __call__(self) -> float:
         """Return the actual logged quantity."""
-        return self._quantity_value
+        val = self._quantity_value
+        self._quantity_value = None
+        return val
 
     def set_quantity_value(self, value: Any) -> None:
         """Set the value of the logged quantity."""

--- a/examples/log.py
+++ b/examples/log.py
@@ -14,16 +14,13 @@ class UserLogQuantity(LogQuantity):
     """Logging support for arbitrary user quantities."""
 
     def __init__(self, name, value=None, unit=None,
-          description=None, user_function=None) -> None:
+          description=None) -> None:
         LogQuantity.__init__(self, name=name, unit=unit,
                              description=description)
         self._quantity_value = value
-        self._uf = user_function
 
     def __call__(self) -> float:
         """Return the actual logged quantity."""
-        if self._uf:
-            return self._uf(self._quantity_value)
         return self._quantity_value
 
     def set_quantity_value(self, value: Any) -> None:

--- a/examples/log.py
+++ b/examples/log.py
@@ -10,7 +10,7 @@ from typing import Any
 from warnings import warn
 
 
-class UserLogQuantity(LogQuantity):
+class PushLogQuantity(LogQuantity):
     """Logging support for arbitrary user quantities."""
 
     def __init__(self, name, value=None, unit=None,
@@ -52,7 +52,7 @@ def main():
     vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
     logmgr.add_quantity(vis_timer)
     logmgr.add_quantity(Fifteen("fifteen"))
-    logmgr.add_quantity(UserLogQuantity("q1", value=0))
+    logmgr.add_quantity(PushLogQuantity("q1", value=0))
 
     # Watches are printed periodically during execution
     logmgr.add_watches(["step.max", "t_sim.max", "t_step.max", "fifteen", "t_vis",

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -747,7 +747,7 @@ class LogManager:
                 value_setter(value)
             else:
                 from warnings import warn
-                warn(f"No value_setter defined for log quantity {name=}.")
+                warn(f"No value_setter defined for log quantity (name={name}).")
 
     def _insert_datapoint(self, name: str, value: Optional[float]) -> None:
         if value is None:


### PR DESCRIPTION
This helps https://github.com/illinois-ceesd/mirgecom/pull/391, and adds a basic value-setting capability for users' logged quantities. The user would be responsible for implementing the capability user-side and making sure it does something useful.   The local logpyle changes just fix it up so that such that a setter function can be registered.

fixes: #68