### PR TITLE
Make _SubTimer reusable

### DIFF
--- a/doc/log.rst
+++ b/doc/log.rst
@@ -102,4 +102,29 @@ your time series data, for example:
   step 2000 and 3000
 - Make a scatterplot correlating memory transfer amounts and simulation time
 
+In some cases (for example, when logging is optional), it may be convenient to
+retrieve sub-timers once and reuse them. Adapting the example above, sub-timer
+initialization becomes::
+
+    # Add a timer quantity and retrieve a sub-timer for later use
+    if logmgr:
+        vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
+        logmgr.add_quantity(vis_timer)
+        time_vis = vis_timer.get_sub_timer()
+    else:
+        from contextlib import nullcontext
+        time_vis = nullcontext()
+
+and usage becomes::
+
+    if istep % 10 == 0:
+        # Use the sub-timer
+        with time_vis:
+            sleep(0.05)
+
+(Full example code can be found in
+:download:`examples/optional-log.py <../examples/optional-log.py>` in the logpyle
+source distribution.)
+
+
 .. no-doctest

--- a/examples/optional-log.py
+++ b/examples/optional-log.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+from time import sleep
+from random import uniform
+from logpyle import (LogManager, add_general_quantities,
+        add_simulation_quantities, add_run_info, IntervalTimer,
+        set_dt)
+
+
+def main(use_logpyle):
+    if use_logpyle:
+        logmgr = LogManager("optional-log.sqlite", "w")
+    else:
+        logmgr = None
+
+    # See examples/log.py for details about these
+    if logmgr:
+        add_run_info(logmgr)
+        add_general_quantities(logmgr)
+        add_simulation_quantities(logmgr)
+
+    # Add a timer quantity and retrieve a sub-timer for later use
+    if logmgr:
+        vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
+        logmgr.add_quantity(vis_timer)
+        time_vis = vis_timer.get_sub_timer()
+    else:
+        from contextlib import nullcontext
+        time_vis = nullcontext()
+
+    if logmgr:
+        logmgr.add_watches(["step.max", "t_sim.max", "t_step.max", "t_vis"])
+
+    for istep in range(200):
+        if logmgr:
+            logmgr.tick_before()
+
+        dt = uniform(0.01, 0.1)
+        if logmgr:
+            set_dt(logmgr, dt)
+
+        sleep(dt)
+
+        if istep % 10 == 0:
+            # Use the sub-timer
+            with time_vis:
+                sleep(0.05)
+
+        if logmgr:
+            logmgr.tick_after()
+
+    if logmgr:
+        logmgr.close()
+
+
+if __name__ == "__main__":
+    main(use_logpyle=True)

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -1194,7 +1194,6 @@ class IntervalTimer(PostLogQuantity):
 
     .. automethod:: __init__
     .. automethod:: get_sub_timer
-    .. automethod:: start_sub_timer
     .. automethod:: add_time
     """
 

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -1165,8 +1165,11 @@ class LogManager:
 class _SubTimer:
     def __init__(self, itimer) -> None:
         self.itimer = itimer
-        self.start_time = time()
         self.elapsed = 0
+
+    def start(self):
+        self.start_time = time()
+        return self
 
     def stop(self):
         self.elapsed += time() - self.start_time
@@ -1174,7 +1177,7 @@ class _SubTimer:
         return self
 
     def __enter__(self) -> None:
-        pass
+        self.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.stop()
@@ -1182,7 +1185,7 @@ class _SubTimer:
 
     def submit(self) -> None:
         self.itimer.add_time(self.elapsed)
-        del self.elapsed
+        self.elapsed = 0
 
 
 class IntervalTimer(PostLogQuantity):
@@ -1198,8 +1201,13 @@ class IntervalTimer(PostLogQuantity):
         LogQuantity.__init__(self, name, "s", description)
         self.elapsed: float = 0
 
-    def start_sub_timer(self):
+    def get_sub_timer(self):
         return _SubTimer(self)
+
+    def start_sub_timer(self):
+        sub_timer = _SubTimer(self)
+        sub_timer.start()
+        return sub_timer
 
     def add_time(self, t: float) -> None:
         self.start_time = time()

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -1193,6 +1193,7 @@ class IntervalTimer(PostLogQuantity):
     sub-timers, or by explicitly calling :meth:`add_time`.
 
     .. automethod:: __init__
+    .. automethod:: get_sub_timer
     .. automethod:: start_sub_timer
     .. automethod:: add_time
     """


### PR DESCRIPTION
I was thinking about what @MTCam said [here](https://github.com/illinois-ceesd/mirgecom/pull/428#issuecomment-879104146), and I wondered if we could somehow tidy up the timing logic a little to make this easier. Right now it looks something like:

```python
    if timer:
        ctm = timer.start_sub_timer()
    else:
        ctm = nullcontext()

    with ctm:
        # execute timed code
```
and this has to be done every time the timer is used, since the timer is started in `timer.start_sub_timer()`. This seems a little too awkward to be pasted all over the drivers IMO.

If instead we made the timer actually start in `__enter__`, we could do the first part once at init time and then only need to do `with ctm:` whenever we want to time something. This PR enables that by:

1. Adding an explicit `start` method to `_SubTimer` and removing the start from `__init__`
2. Allowing `_SubTimer` to `__enter__` and `__exit__` multiple times
3. Adding a `get_sub_timer` method to `IntervalTimer` that creates the `_SubTimer` but does not start it.