### PR TITLE
Only enable logging/warning capture on writing

### DIFF
--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -622,12 +622,12 @@ class LogManager:
 
         self.warning_data: List[_LogWarningInfo] = []
         self.old_showwarning: Optional[Callable[..., Any]] = None
-        if capture_warnings:
+        if capture_warnings and self.mode[0] == "w":
             self.capture_warnings(True)
 
         self.logging_data: List[_LogWarningInfo] = []
         self.logging_handler: Optional[logging.Handler] = None
-        if capture_logging:
+        if capture_logging and self.mode[0] == "w":
             self.capture_logging(True)
 
         # }}}


### PR DESCRIPTION
Avoids errors when opening older Sqlite files for reading.

Before:

```
$ runalyzer-gather out2.db old.sqlite
Trouble with file 'old.sqlite'
Traceback (most recent call last):
  File "/Users/mdiener/Work/emirge/miniforge3/envs/ceesd/bin/runalyzer-gather", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/mdiener/Work/emirge/logpyle/bin/runalyzer-gather", line 397, in <module>
    main()
  File "/Users/mdiener/Work/emirge/logpyle/bin/runalyzer-gather", line 383, in main
    features, dbname_to_run_id = scan(fg, infiles)
                                 ^^^^^^^^^^^^^^^^^
  File "/Users/mdiener/Work/emirge/logpyle/bin/runalyzer-gather", line 149, in scan
    logmgr = LogManager(dbname, "r")
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mdiener/Work/emirge/logpyle/logpyle/__init__.py", line 626, in __init__
    self.capture_warnings(True)
  File "/Users/mdiener/Work/emirge/logpyle/logpyle/__init__.py", line 656, in capture_warnings
    raise ValueError("Warnings capture needs at least schema_version 3, "
ValueError: Warnings capture needs at least schema_version 3,  got 2
```

After:

```
$ runalyzer-gather out2.db old.sqlite
Scanning...          [########################################] ETA ?
/Users/mdiener/Work/emirge/logpyle/logpyle/__init__.py:713: UserWarning: This database lacks a 'logging' table
  warn("This database lacks a 'logging' table")
```