### PR TITLE
Optional param now defaults to None instead of empty string.

### DIFF
--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -189,11 +189,11 @@ class MultiLogQuantity:
         self.names = names
 
         if units is None:
-            units = len(names) * [""]
+            units = len(names) * [None]
         self.units = units
 
         if descriptions is None:
-            descriptions = len(names) * [""]
+            descriptions = len(names) * [None]
         self.descriptions = descriptions
 
     @property

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -171,8 +171,9 @@ class MultiLogQuantity:
     """
     sort_weight = 0
 
-    def __init__(self, names: List[str], units: Optional[List[str]] = None,
-                 descriptions: Optional[List[str]] = None) -> None:
+    def __init__(self, names: List[str],
+                 units: Optional[Sequence[Optional[str]]] = None,
+                 descriptions: Optional[Sequence[Optional[str]]] = None) -> None:
         """Create a new quantity.
 
         Parameters

--- a/logpyle/__init__.py
+++ b/logpyle/__init__.py
@@ -172,8 +172,8 @@ class MultiLogQuantity:
     sort_weight = 0
 
     def __init__(self, names: List[str],
-                 units: Optional[Sequence[Optional[str]]] = None,
-                 descriptions: Optional[Sequence[Optional[str]]] = None) -> None:
+                 units: Optional[List[Optional[str]]] = None,
+                 descriptions: Optional[List[Optional[str]]] = None) -> None:
         """Create a new quantity.
 
         Parameters
@@ -190,12 +190,14 @@ class MultiLogQuantity:
         self.names = names
 
         if units is None:
-            units = len(names) * [None]
-        self.units = units
+            self.units = cast(list[Optional[str]], len(names) * [None])
+        else:
+            self.units = units
 
         if descriptions is None:
-            descriptions = len(names) * [None]
-        self.descriptions = descriptions
+            self.descriptions = cast(list[Optional[str]], len(names) * [None])
+        else:
+            self.descriptions = descriptions
 
     @property
     def default_aggregators(self) -> List[None]:
@@ -1698,7 +1700,8 @@ class GCStats(MultiPostLogQuantity):
 
         assert len(names) == len(units) == len(descriptions) == 13
 
-        super().__init__(names, units, descriptions)
+        super().__init__(names, cast(List[Optional[str]], units),
+                         cast(List[Optional[str]], descriptions))
 
     def __call__(self) -> Iterable[Optional[float]]:
         import gc


### PR DESCRIPTION
This should fix a crash that occurs when getting the data from the LogManager when a MultiLogQuantity was initialized with the units of type None. 
This fix passes the currently pending testing suite PR.
The crash was due to parsing an empty string:
`pytools.lex.ParseError: unexpected end of input at end of input`

This change makes MultiLogQuantity more similar to LogQuantity as the parameter is passed straight through. 
```
class LogQuantity:
    ...
    def __init__(self, name: str, unit: Optional[str] = None,
                 description: Optional[str] = None) -> None:
       ...
        self.name = name
        self.unit = unit
        self.description = description
```
This should address issue #123 