### PR TITLE
re-enabled empty_multi_test after null units fix was applied

### DIFF
--- a/test/test_quantities.py
+++ b/test/test_quantities.py
@@ -237,14 +237,13 @@ test_MultiLogQuantity_types = [
             ["Q init to 1", None],
             lambda x, y: [x+1, y+1]
          ),
-        # fix for null units not yet implemented
-        # (
-        #     ["Quantity_1", "Quantity_2"],
-        #     [1, 2],
-        #     None,
-        #     ["Q init to 1", "Q init to 2"],
-        #     lambda x, y: [x+1, y+1]
-        #  ),
+        (
+            ["Quantity_1", "Quantity_2"],
+            [1, 2],
+            None,
+            ["Q init to 1", "Q init to 2"],
+            lambda x, y: [x+1, y+1]
+         ),
         (
             ["Quantity_1", "Quantity_2"],
             [1, 2],


### PR DESCRIPTION
The previously failing test was disabled while the fix was being finalized.