### PR TITLE
Testing of optional modules now skips those tests

### DIFF
--- a/test/test_logManager.py
+++ b/test/test_logManager.py
@@ -502,8 +502,6 @@ def test_time_and_count_function(basicLogmgr: LogManager):
 
 
 def test_joint_dataset(basicLogmgr: LogManager):
-    pytest.importorskip("psutil")
-
     add_general_quantities(basicLogmgr)
     basicLogmgr.tick_before()
     basicLogmgr.tick_after()
@@ -513,13 +511,11 @@ def test_joint_dataset(basicLogmgr: LogManager):
         "t_step",
         ("cpu time", Variable("s"), "t_wall"),
         "memory_usage_hwm",
-        "t_init",
     ]
     quantityNames = [
         "t_step",
         "cpu time",
         "memory_usage_hwm",
-        "t_init",
     ]
     dataset = basicLogmgr.get_joint_dataset(idealQuantitiesAdded)
 

--- a/test/test_logManager.py
+++ b/test/test_logManager.py
@@ -502,6 +502,8 @@ def test_time_and_count_function(basicLogmgr: LogManager):
 
 
 def test_joint_dataset(basicLogmgr: LogManager):
+    pytest.importorskip("psutil")
+
     add_general_quantities(basicLogmgr)
     basicLogmgr.tick_before()
     basicLogmgr.tick_after()
@@ -611,6 +613,8 @@ def test_write_datafile(basicLogmgr: LogManager):
 
 
 def test_plot_matplotlib(basicLogmgr: LogManager):
+    pytest.importorskip("matplotlib")
+
     add_general_quantities(basicLogmgr)
 
     N = 20


### PR DESCRIPTION
Neither the psutil nor matplotlib modules are requirements of logpyle. If they are not present in the environment when running tests, those tests that use them will be skipped.