### PR TITLE
runalyzer-gather: check if file exists before creating tables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,6 @@ jobs:
             pip install -e .
             python -m pip install pytest pymbolic psutil matplotlib mpi4py
 
-            # run current test coverage
             python -m pytest --durations=5 --tb=native -rxsw test/
 
     coverage:

--- a/logpyle/runalyzer_gather.py
+++ b/logpyle/runalyzer_gather.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sqlite3
 from sqlite3 import Connection
@@ -223,6 +224,11 @@ def gather_multi_file(outfile: str, infiles: list[str], fmap: dict[str, str],
             feature_col_name_map[fname] = tgt_name + "_"
         else:
             feature_col_name_map[fname] = tgt_name
+
+    if os.path.exists(outfile):
+        print(f"Error: output file '{outfile}' already exists, exiting.")
+        import sys
+        sys.exit(1)
 
     import sqlite3
     db_conn = sqlite3.connect(outfile)

--- a/logpyle/runalyzer_gather.py
+++ b/logpyle/runalyzer_gather.py
@@ -225,7 +225,7 @@ def gather_multi_file(outfile: str, infiles: list[str], fmap: dict[str, str],  #
         else:
             feature_col_name_map[fname] = tgt_name
 
-    if os.path.exists(outfile):
+    if os.path.exists(outfile):  # pragma: no cover
         print(f"Error: output file '{outfile}' already exists, exiting.")
         import sys
         sys.exit(1)

--- a/logpyle/runalyzer_gather.py
+++ b/logpyle/runalyzer_gather.py
@@ -209,7 +209,7 @@ def _normalize_types(x: Any) -> Any:
     return x
 
 
-def gather_multi_file(outfile: str, infiles: list[str], fmap: dict[str, str],
+def gather_multi_file(outfile: str, infiles: list[str], fmap: dict[str, str],  # noqa: C901
                       qmap: dict[str, str], fg: FeatureGatherer,
                       features: dict[str, Any],
                       dbname_to_run_id: dict[str, int]) -> sqlite3.Connection:


### PR DESCRIPTION
Otherwise, a strange error message is shown:

before:
```console
$ runalyzer-gather out.sqlite mpi*sqlite
Scanning...          [########################################] ETA ?
Traceback (most recent call last):
  File "/Users/mdiener/Work/emirge/miniforge3/envs/sqlite/bin/runalyzer-gather", line 57, in <module>
    main()
  File "/Users/mdiener/Work/emirge/miniforge3/envs/sqlite/bin/runalyzer-gather", line 53, in main
    gather_multi_file(outfile, infiles, fmap, qmap, fg, features, dbname_to_run_id)
  File "/Users/mdiener/Work/emirge/logpyle/logpyle/runalyzer_gather.py", line 246, in gather_multi_file
    db_conn.execute("create table runs ({})".format(",".join(run_columns)))
sqlite3.OperationalError: table runs already exists
```

after:
```console
$ runalyzer-gather ../logpyle/out.sqlite mpi*sqlite
Scanning...          [########################################] ETA ?
Error: output file '../logpyle/out.sqlite' already exists, exiting.
```