### PR TITLE
link to sphinx configuration for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,9 +10,9 @@ python:
       path: .
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     post_install:
       - pip install sphinx-copybutton furo

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,7 @@ version: 2
 
 sphinx:
   fail_on_warning: true
+  configuration: doc/conf.py
 
 python:
   install:


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/